### PR TITLE
Add market stats fetch

### DIFF
--- a/app/api/stockstats/route.js
+++ b/app/api/stockstats/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const symbol = searchParams.get('symbol');
+  if (!symbol) {
+    return NextResponse.json({ error: 'Missing symbol' }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(
+      `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?range=1y&interval=1d`,
+      {
+        headers: { 'User-Agent': 'Mozilla/5.0' },
+      }
+    );
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Failed to fetch data' }, { status: 500 });
+    }
+    const json = await res.json();
+    const result = json.chart?.result?.[0];
+    const prices = result?.indicators?.adjclose?.[0]?.adjclose || [];
+    const returns = [];
+    for (let i = 1; i < prices.length; i++) {
+      const prev = prices[i - 1];
+      const curr = prices[i];
+      if (prev != null && curr != null && prev > 0) {
+        returns.push(Math.log(curr / prev));
+      }
+    }
+    if (returns.length === 0) {
+      return NextResponse.json(
+        { error: 'Insufficient data for symbol' },
+        { status: 500 }
+      );
+    }
+    const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+    const variance =
+      returns.reduce((a, b) => a + (b - mean) ** 2, 0) / returns.length;
+    const drift = mean * 100;
+    const volatility = Math.sqrt(variance) * 100;
+    return NextResponse.json({ drift, volatility });
+  } catch (err) {
+    return NextResponse.json({ error: 'Error: ' + err.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add an API route `/api/stockstats` that pulls one year of data from Yahoo Finance and computes drift and volatility
- extend Brownian simulator page with a ticker input and button to load drift and volatility values

## Testing
- `npm run lint` *(fails: React Hook missing dependency warning)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a35f7a9ec8323ad2dfc1867c9822e