### PR TITLE
Add interval selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Or Manually
    npm install react-chartjs-2 chart.js
    ```
 2. Start the development server:
-   ```bash
-   npx next dev
-   ```
-3. Open `http://localhost:3000` in your browser and click **Launch Simulator** to access the Brownian page.
+ ```bash
+  npx next dev
+  ```
+3. Open `http://localhost:3000` in your browser and click **Launch Simulator** to access the Brownian page. Use the interval dropdown to fetch historical data in daily, hourly, or 5 minute increments.
 
 ## App Structure
 
@@ -57,11 +57,11 @@ Chart.js renders these points as a line chart that continuously updates while th
 
 ## Stock Statistics Endpoint
 
-The API route `/api/stockstats` retrieves recent daily prices for a symbol from Yahoo Finance, computes log returns, and returns the mean (drift) and standard deviation (volatility):
+The API route `/api/stockstats` retrieves historical prices for a symbol from Yahoo Finance. You can pass a query parameter `interval` (`1d`, `1h`, or `5m`) to control the data resolution. The endpoint computes log returns and returns the mean (drift) and standard deviation (volatility):
 
 ```javascript
 const res = await fetch(
-  `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?range=1y&interval=1d`,
+  `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?range=${range}&interval=${interval}`,
   { headers: { 'User-Agent': 'Mozilla/5.0' } }
 );
 const json = await res.json();
@@ -107,7 +107,7 @@ These values are returned to the client and can pre-fill the simulator inputs.
   ```
   【F:app/layout.js†L19-L28】
 
-- **Simulation Controls** – Users can adjust initial price, volatility, drift, and the number of points displayed. When running, the graph updates every two seconds.
+- **Simulation Controls** – Users can adjust initial price, volatility, drift, and the number of points displayed. You can also choose the historical data interval (1d, 1h, or 5m) used to seed the simulator. When running, the graph updates every two seconds.
 
 ## License
 

--- a/app/api/stockstats/route.js
+++ b/app/api/stockstats/route.js
@@ -3,13 +3,18 @@ import { NextResponse } from 'next/server';
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
   const symbol = searchParams.get('symbol');
+  const intervalParam = searchParams.get('interval') || '1d';
+  const allowed = ['1d', '1h', '5m'];
+  const interval = allowed.includes(intervalParam) ? intervalParam : '1d';
+  const rangeMap = { '1d': '1y', '1h': '1mo', '5m': '1mo' };
+  const range = rangeMap[interval];
   if (!symbol) {
     return NextResponse.json({ error: 'Missing symbol' }, { status: 400 });
   }
 
   try {
     const res = await fetch(
-      `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?range=1y&interval=1d`,
+      `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?range=${range}&interval=${interval}`,
       {
         headers: { 'User-Agent': 'Mozilla/5.0' },
       }

--- a/app/brownian/page.js
+++ b/app/brownian/page.js
@@ -31,6 +31,7 @@ export default function BrownianSimulator() {
   const [volatility, setVolatility] = useState(1); // Stored as percentage (1 = 1%)
   const [drift, setDrift] = useState(0.1); // Stored as percentage (0.1 = 0.1%)
   const [days, setDays] = useState(100);
+  const [interval, setInterval] = useState("1d");
   const [dataPoints, setDataPoints] = useState([]);
   const [isRunning, setIsRunning] = useState(false);
   const [symbol, setSymbol] = useState("");
@@ -73,7 +74,9 @@ export default function BrownianSimulator() {
     setLoading(true);
     setError("");
     try {
-      const res = await fetch(`/api/stockstats?symbol=${normalized}`);
+      const res = await fetch(
+        `/api/stockstats?symbol=${normalized}&interval=${interval}`
+      );
       if (!res.ok) {
         throw new Error('Failed to fetch');
       }
@@ -121,7 +124,12 @@ export default function BrownianSimulator() {
       x: {
         title: {
           display: true,
-          text: "Time (Days)",
+          text:
+            interval === "1d"
+              ? "Time (Days)"
+              : interval === "1h"
+              ? "Time (Hours)"
+              : "Time",
           color: "#ddd",
           font: { size: 16, weight: "bold" },
         },
@@ -288,6 +296,20 @@ export default function BrownianSimulator() {
               onChange={(e) => setDrift(parseFloat(e.target.value) || 0)}
               className="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 text-white bg-gray-800"
             />
+          </label>
+
+          <label className="flex flex-col">
+            <span className="font-semibold mb-1 text-gray-300">Interval</span>
+            <select
+              disabled={isRunning}
+              value={interval}
+              onChange={(e) => setInterval(e.target.value)}
+              className="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 text-white bg-gray-800"
+            >
+              <option value="1d">1d</option>
+              <option value="1h">1h</option>
+              <option value="5m">5m</option>
+            </select>
           </label>
 
           <label className="flex flex-col">


### PR DESCRIPTION
## Summary
- add interval parameter to `BrownianSimulator`
- validate interval and adjust range on the stock stats API
- document the new interval feature

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bf69b120c8323b8bbe2d12f9ac9b2